### PR TITLE
fix: allowing attribute values to have parentheses

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@
   function validDataUrl(s) {
     return validDataUrl.regex.test((s || '').trim());
   }
-  validDataUrl.regex = /^data:([a-z]+\/[a-z0-9-+.]+(;[a-z0-9-.!#$%*+.{}|~`]+=[a-z0-9-.!#$%*+.{}|~`]+)*)?(;base64)?,([a-z0-9!$&',()*+;=\-._~:@\/?%\s]*?)$/i;
+  validDataUrl.regex = /^data:([a-z]+\/[a-z0-9-+.]+(;[a-z0-9-.!#$%*+.{}|~`]+=[a-z0-9-.!#$%*+.{}()|~`]+)*)?(;base64)?,([a-z0-9!$&',()*+;=\-._~:@\/?%\s]*?)$/i;
 
   return validDataUrl;
 }));

--- a/test.js
+++ b/test.js
@@ -18,7 +18,8 @@ const valid = [
   'data:text/html;charset=US-ASCII,%3Ch1%3EHello!%3C%2Fh1%3E',
   'data:audio/mp3;base64,%3Ch1%3EHello!%3C%2Fh1%3E',
   'data:video/x-ms-wmv;base64,%3Ch1%3EHello!%3C%2Fh1%3E',
-  'data:application/vnd.ms-excel;base64,PGh0bWw%2BPC9odG1sPg%3D%3D'
+  'data:application/vnd.ms-excel;base64,PGh0bWw%2BPC9odG1sPg%3D%3D',
+  'data:image/svg+xml;name=foobar%20(1).svg;charset=UTF-8,some-data'
 ];
 
 const invalid = [


### PR DESCRIPTION
This updates the regex to allow for attribute values to contain parentheses.

Resolves https://github.com/killmenot/valid-data-url/issues/5