### PR TITLE
fix: allowing underscores to be present in attribute values

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@
   function validDataUrl(s) {
     return validDataUrl.regex.test((s || '').trim());
   }
-  validDataUrl.regex = /^data:([a-z]+\/[a-z0-9-+.]+(;[a-z0-9-.!#$%*+.{}|~`]+=[a-z0-9-.!#$%*+.{}()|~`]+)*)?(;base64)?,([a-z0-9!$&',()*+;=\-._~:@\/?%\s<>]*?)$/i;
+  validDataUrl.regex = /^data:([a-z]+\/[a-z0-9-+.]+(;[a-z0-9-.!#$%*+.{}|~`]+=[a-z0-9-.!#$%*+.{}()_|~`]+)*)?(;base64)?,([a-z0-9!$&',()*+;=\-._~:@\/?%\s<>]*?)$/i;
 
   return validDataUrl;
 }));

--- a/test.js
+++ b/test.js
@@ -20,6 +20,7 @@ const valid = [
   'data:video/x-ms-wmv;base64,%3Ch1%3EHello!%3C%2Fh1%3E',
   'data:application/vnd.ms-excel;base64,PGh0bWw%2BPC9odG1sPg%3D%3D',
   'data:image/svg+xml;name=foobar%20(1).svg;charset=UTF-8,some-data',
+  'data:image/svg+xml;name=lorem_ipsum.txt;charset=UTF-8,some-data',
   'data:text/html,<script>alert(\'hi\');</script>'
 ];
 


### PR DESCRIPTION
Similar to the fix I did in https://github.com/killmenot/valid-data-url/pull/6 this allows underscores to be present in attribute values.

As like in #6, as far as I can tell underscores are valid here because they're unreserved for `encodeURI()` and `encodeURIComponent()`.